### PR TITLE
Refactor/company/#120 업체, 주문과 허브 일부 리팩토링

### DIFF
--- a/com.delivery-signal.eureka.client.company/src/main/java/com/delivery_signal/eureka/client/company/domain/entity/Product.java
+++ b/com.delivery-signal.eureka.client.company/src/main/java/com/delivery_signal/eureka/client/company/domain/entity/Product.java
@@ -2,11 +2,9 @@ package com.delivery_signal.eureka.client.company.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.extern.java.Log;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Entity
@@ -32,7 +30,7 @@ public class Product extends BaseEntity{
     @Column(name = "hub_id")
     private UUID hubId;
 
-    @Column(name = "상품가격")
+    @Column(name = "price")
     private BigDecimal price;
 
     @Column(name = "deleted_by")

--- a/com.delivery-signal.eureka.client.company/src/main/java/com/delivery_signal/eureka/client/company/presentation/internal/controller/CompanyInternalController.java
+++ b/com.delivery-signal.eureka.client.company/src/main/java/com/delivery_signal/eureka/client/company/presentation/internal/controller/CompanyInternalController.java
@@ -43,11 +43,10 @@ public class CompanyInternalController {
                 **GET /open-api/v1/companies/{company-id}**
                 """)
     @GetMapping("/{company-id}")
-    public ResponseEntity<ApiResponse<OrderCompanyResponseDto>> getCompanyById(@PathVariable("company-id") UUID companyId) {
+    public OrderCompanyResponseDto getCompanyById(@PathVariable("company-id") UUID companyId) {
         log.info("내부 서비스에서 업체 조회 요청: {}", companyId);
 
         OrderCompanyResult result = internalCompanyService.getCompanyInfo(companyId);
-        OrderCompanyResponseDto responseDto = OrderCompanyResponseMapper.toResponse(result);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(responseDto));
+        return OrderCompanyResponseMapper.toResponse(result);
     }
 }

--- a/com.delivery-signal.eureka.client.company/src/main/java/com/delivery_signal/eureka/client/company/presentation/internal/controller/ProductInternalController.java
+++ b/com.delivery-signal.eureka.client.company/src/main/java/com/delivery_signal/eureka/client/company/presentation/internal/controller/ProductInternalController.java
@@ -1,6 +1,5 @@
 package com.delivery_signal.eureka.client.company.presentation.internal.controller;
 
-import com.delivery_signal.eureka.client.company.application.dto.ApiResponse;
 import com.delivery_signal.eureka.client.company.application.result.OrderProductResult;
 import com.delivery_signal.eureka.client.company.application.service.InternalOrderProductService;
 import com.delivery_signal.eureka.client.company.presentation.internal.dto.response.OrderProductResponseDto;
@@ -44,11 +43,10 @@ public class ProductInternalController {
                 **GET /open-api/v1/products?productIds=uuid1,uuid2,uuid3**
                 """)
     @GetMapping(params = "productIds")
-    public ResponseEntity<ApiResponse<List<OrderProductResponseDto>>> getProducts(@RequestParam List<UUID> productIds) {
+    public List<OrderProductResponseDto> getProducts(@RequestParam List<UUID> productIds) {
         log.info("내부 서비스에서 상품 조회 요청: {}", productIds);
 
         List<OrderProductResult> results = internalProductService.getProducts(productIds);
-        List<OrderProductResponseDto> responseDtos = OrderProductResponseMapper.toResponseList(results);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(responseDtos));
+        return OrderProductResponseMapper.toResponseList(results);
     }
 }

--- a/com.delivery-signal.eureka.client.company/src/main/resources/application.yaml
+++ b/com.delivery-signal.eureka.client.company/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ spring:
   jpa:
     properties:
       hibernate:
-        default_schema: company
+        default_schema: p_company
     hibernate:
       ddl-auto: update
     show-sql: true

--- a/com.delivery-signal.eureka.client.hub/src/main/java/com/delivery_signal/eureka/client/hub/presentation/controller/HubOpenApiController.java
+++ b/com.delivery-signal.eureka.client.hub/src/main/java/com/delivery_signal/eureka/client/hub/presentation/controller/HubOpenApiController.java
@@ -53,7 +53,7 @@ public class HubOpenApiController {
 		@PathVariable UUID hubId,
 		@Valid @RequestBody DeductStockQuantityRequest request
 	) {
-		DeductStockQuantityCommand command = DeductStockQuantityCommand.of(hubId, request.items());
+		DeductStockQuantityCommand command = DeductStockQuantityCommand.of(hubId, request.products());
 		stockFacade.deductStocks(command);
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("재고 차감이 완료되었습니다."));
 	}
@@ -63,7 +63,7 @@ public class HubOpenApiController {
 		@PathVariable UUID hubId,
 		@Valid @RequestBody RestoreStockQuantityRequest request
 	) {
-		RestoreStockQuantityCommand command = RestoreStockQuantityCommand.of(hubId, request.items());
+		RestoreStockQuantityCommand command = RestoreStockQuantityCommand.of(hubId, request.products());
 		stockFacade.restoreStocks(command);
 		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success("재고 복구가 완료되었습니다."));
 	}

--- a/com.delivery-signal.eureka.client.hub/src/main/java/com/delivery_signal/eureka/client/hub/presentation/dto/request/DeductStockQuantityRequest.java
+++ b/com.delivery-signal.eureka.client.hub/src/main/java/com/delivery_signal/eureka/client/hub/presentation/dto/request/DeductStockQuantityRequest.java
@@ -7,5 +7,5 @@ import jakarta.validation.constraints.NotEmpty;
 
 public record DeductStockQuantityRequest(
 	@NotEmpty(message = "상품 목록은 비어 있을 수 없습니다.")
-	Map<UUID, Integer> items
+	Map<UUID, Integer> products
 ) {}

--- a/com.delivery-signal.eureka.client.hub/src/main/java/com/delivery_signal/eureka/client/hub/presentation/dto/request/RestoreStockQuantityRequest.java
+++ b/com.delivery-signal.eureka.client.hub/src/main/java/com/delivery_signal/eureka/client/hub/presentation/dto/request/RestoreStockQuantityRequest.java
@@ -7,5 +7,5 @@ import jakarta.validation.constraints.NotEmpty;
 
 public record RestoreStockQuantityRequest(
 	@NotEmpty(message = "상품 목록은 비어 있을 수 없습니다.")
-	Map<UUID, Integer> items
+	Map<UUID, Integer> products
 ) {}

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/application/command/CreateDeliveryCommand.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/application/command/CreateDeliveryCommand.java
@@ -15,7 +15,6 @@ import java.util.UUID;
 public class CreateDeliveryCommand {
     private Long userId;
     private String userRole;
-    private UUID deliveryId;          // 주문에서 미리 생성한 UUID
     private UUID orderId;             // 주문 PK
     private UUID supplierCompanyId;   // 출발 업체 ID (공급자)
     private UUID receiverCompanyId;   // 도착 업체 ID (수령자)

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/application/port/out/HubCommandPort.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/application/port/out/HubCommandPort.java
@@ -1,7 +1,7 @@
 package com.delivery_signal.eureka.client.order.application.port.out;
 
-import com.delivery_signal.eureka.client.order.application.command.OrderProductCommand;
-import java.util.List;
+
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -10,6 +10,6 @@ import java.util.UUID;
  */
 public interface HubCommandPort {
 
-    void deductStocks(UUID hubId, List<OrderProductCommand> products);
-    void restoreStocks(UUID hubId, List<OrderProductCommand> products);
+    void deductStocks(UUID hubId, Map<UUID, Integer> products);
+    void restoreStocks(UUID hubId, Map<UUID, Integer>  products);
 }

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/application/service/OrderService.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/application/service/OrderService.java
@@ -133,11 +133,6 @@ public class OrderService {
         log.info("[ORDER] 상품 수량 맵 생성 완료: {}", productQuantityMap);
 
 
-        // 배송 ID 미리 생성
-        UUID deliveryId = UUID.randomUUID();
-        log.info("[ORDER] 배송ID 생성됨 = {}", deliveryId);
-
-
         // [LOG] 도메인 주문 생성
         log.info("[ORDER] 도메인 createOrder 시작");
         Order order = orderDomainService.createOrder(
@@ -147,8 +142,7 @@ public class OrderService {
                 receiver.getHubId(),
                 command.getRequestNote(),
                 productInfos,
-                productQuantityMap,
-                deliveryId
+                productQuantityMap
         );
         log.info("[ORDER] 도메인 createOrder 성공 -> orderId={}", order.getId());
 
@@ -167,14 +161,12 @@ public class OrderService {
 
 
         // [LOG] 배송 생성 요청
-        log.info("[ORDER] 배송 생성 요청 시작: deliveryId={}, orderId={}",
-                deliveryId, order.getId());
+        log.info("[ORDER] 배송 생성 요청 시작:orderId={}", order.getId());
 
         DeliveryCreatedInfo deliveryInfo = deliveryCommandPort.createDelivery(
                 CreateDeliveryCommand.builder()
                         .userId(command.getUserId())
                         .userRole(userRole)
-                        .deliveryId(deliveryId)
                         .orderId(order.getId())
                         .supplierCompanyId(command.getSupplierCompanyId())
                         .receiverCompanyId(command.getReceiverCompanyId())
@@ -289,6 +281,11 @@ public class OrderService {
                 .build();
     }
 
+    /**
+     * 주문 취소
+     * @param command
+     * @return
+     */
     @Transactional
     public OrderCancelResult cancelOrder(OrderCancelCommand command) {
 

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/domain/entity/Order.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/domain/entity/Order.java
@@ -75,28 +75,39 @@ public class Order {
     private LocalDateTime deletedAt;
     private Long deletedBy;
 
-    public Order(String requestNote) {
-        this.requestNote = requestNote;
-    }
-
-    @Builder
-    public Order(UUID supplierCompanyId,
-                 UUID receiverCompanyId,
-                 UUID departureHubId,
-                 UUID arrivalHubId,
-                 String requestNote,
-                 BigDecimal totalPriceAtOrder,
-                 List<OrderProduct> orderProducts,
-                 UUID deliveryId) {
+    private Order(
+            UUID supplierCompanyId,
+            UUID receiverCompanyId,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            String requestNote,
+            BigDecimal totalPriceAtOrder,
+            UUID deliveryId
+    ) {
         this.supplierCompanyId = supplierCompanyId;
         this.receiverCompanyId = receiverCompanyId;
         this.departureHubId = departureHubId;
         this.arrivalHubId = arrivalHubId;
         this.requestNote = requestNote;
         this.totalPriceAtOrder = totalPriceAtOrder;
-        this.orderProducts = orderProducts;
         this.deliveryId = deliveryId;
         this.status = OrderStatus.VALID;
+    }
+
+    public static Order of(
+            UUID supplierCompanyId,
+            UUID receiverCompanyId,
+            UUID departureHubId,
+            UUID arrivalHubId,
+            String requestNote,
+            BigDecimal totalPriceAtOrder,
+            UUID deliveryId
+    ) {
+        return new Order(
+                supplierCompanyId, receiverCompanyId,
+                departureHubId, arrivalHubId,
+                requestNote, totalPriceAtOrder, deliveryId
+        );
     }
 
     /**

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/domain/entity/OrderProduct.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/domain/entity/OrderProduct.java
@@ -58,20 +58,30 @@ public class OrderProduct{
     private LocalDateTime deletedAt;
     private Long deletedBy;
 
-    public static OrderProduct create(Order order, UUID productId, String name, BigDecimal price, Integer qty) {
-        /**
-         * 외부호출에서 들어오는 값에 대한 예외처리, 아직 연결 전 이므로 주석처리
-         */
-//        if (productId == null) throw new IllegalArgumentException("productId required");
-//        if (name == null || name.isBlank()) throw new IllegalArgumentException("productName required");
-//        if (price == null || price.signum() < 0) throw new IllegalArgumentException("invalid price");
+    // ===========================
+    // 정적 팩토리 메서드
+    // ===========================
+    public static OrderProduct create(
+            Order order,
+            UUID productId,
+            String productName,
+            BigDecimal price,
+            Integer quantity
+    ) {
+
+        if (order == null) throw new IllegalArgumentException("Order cannot be null");
+        if (productId == null) throw new IllegalArgumentException("productId required");
+        if (productName == null || productName.isBlank()) throw new IllegalArgumentException("productName required");
+        if (price == null || price.signum() < 0) throw new IllegalArgumentException("Invalid product price");
+        if (quantity == null || quantity <= 0) throw new IllegalArgumentException("Quantity must be > 0");
 
         OrderProduct p = new OrderProduct();
         p.order = order;
         p.productId = productId;
-        p.productName = name;
+        p.productName = productName;
         p.productPriceAtOrder = price;
-        p.transferQuantity = qty;
+        p.transferQuantity = quantity;
+
         return p;
     }
 

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/domain/service/OrderDomainService.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/domain/service/OrderDomainService.java
@@ -3,11 +3,13 @@ package com.delivery_signal.eureka.client.order.domain.service;
 import com.delivery_signal.eureka.client.order.domain.entity.Order;
 import com.delivery_signal.eureka.client.order.domain.entity.OrderProduct;
 import com.delivery_signal.eureka.client.order.domain.repository.OrderRepository;
+import com.delivery_signal.eureka.client.order.domain.vo.product.ProductInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -16,30 +18,62 @@ public class OrderDomainService {
 
     private final OrderRepository orderRepository;
 
+
+    /**
+     * 도메인 규칙에 따라 Order + OrderProduct를 모두 조립하는 팩토리 역할
+     */
     public Order createOrder(
             UUID supplierCompanyId,
             UUID receiverCompanyId,
             UUID departureHubId,
             UUID arrivalHubId,
             String requestNote,
-            List<OrderProduct> orderProducts,
+            List<ProductInfo> productInfos,
+            Map<UUID, Integer> productQuantities,
             UUID deliveryId
     ) {
-        BigDecimal totalPrice = orderProducts.stream()
-                .map(p -> p.getProductPriceAtOrder()
-                        .multiply(BigDecimal.valueOf(p.getTransferQuantity())))
+        // 1. 총 금액 계산
+        BigDecimal totalPrice = productInfos.stream()
+                .map(info -> {
+                    Integer qty = productQuantities.get(info.getProductId());
+                    if (qty == null || qty <= 0) {
+                        throw new IllegalArgumentException("수량 정보가 유효하지 않습니다. productId=" + info.getProductId());
+                    }
+                    return info.getPrice()
+                            .multiply(BigDecimal.valueOf(qty));
+                })
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        return Order.builder()
-                .supplierCompanyId(supplierCompanyId)
-                .receiverCompanyId(receiverCompanyId)
-                .departureHubId(departureHubId)
-                .arrivalHubId(arrivalHubId)
-                .requestNote(requestNote)
-                .totalPriceAtOrder(totalPrice)
-                .orderProducts(orderProducts)
-                .deliveryId(deliveryId)
-                .build();
+        // 2. Order 생성
+        Order order = Order.of(
+                supplierCompanyId,
+                receiverCompanyId,
+                departureHubId,
+                arrivalHubId,
+                requestNote,
+                totalPrice,
+                deliveryId
+        );
+
+        // 3. OrderProduct 생성 + 연관관계 설정
+        for (ProductInfo info : productInfos) {
+            Integer qty = productQuantities.get(info.getProductId());
+            if (qty == null || qty <= 0) {
+                throw new IllegalArgumentException("수량 정보가 유효하지 않습니다. productId=" + info.getProductId());
+            }
+
+            OrderProduct op = OrderProduct.create(
+                    order,
+                    info.getProductId(),
+                    info.getProductName(),
+                    info.getPrice(),
+                    qty
+            );
+
+            order.getOrderProducts().add(op);
+        }
+
+        return order;
     }
 
 

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/domain/service/OrderDomainService.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/domain/service/OrderDomainService.java
@@ -29,8 +29,7 @@ public class OrderDomainService {
             UUID arrivalHubId,
             String requestNote,
             List<ProductInfo> productInfos,
-            Map<UUID, Integer> productQuantities,
-            UUID deliveryId
+            Map<UUID, Integer> productQuantities
     ) {
         // 1. 총 금액 계산
         BigDecimal totalPrice = productInfos.stream()
@@ -52,7 +51,7 @@ public class OrderDomainService {
                 arrivalHubId,
                 requestNote,
                 totalPrice,
-                deliveryId
+                null //주문 생성 시 배송id는 null처리
         );
 
         // 3. OrderProduct 생성 + 연관관계 설정

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/adapter/out/CompanyQueryAdapter.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/adapter/out/CompanyQueryAdapter.java
@@ -21,12 +21,12 @@ public class CompanyQueryAdapter implements CompanyQueryPort {
 
     @Override
     public CompanyInfo getCompanyById(UUID companyId) {
-        return companyClient.getCompanyById(companyId).getData();
+        return companyClient.getCompanyById(companyId);
     }
 
     @Override
     public List<ProductInfo> getProducts(List<UUID> productIds) {
-        return companyClient.getProducts(productIds).getData();
+        return companyClient.getProducts(productIds);
     }
 }
 

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/adapter/out/HubCommandAdapter.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/adapter/out/HubCommandAdapter.java
@@ -1,13 +1,12 @@
 package com.delivery_signal.eureka.client.order.infrastructure.adapter.out;
 
-import com.delivery_signal.eureka.client.order.application.command.OrderProductCommand;
 import com.delivery_signal.eureka.client.order.application.port.out.HubCommandPort;
 import com.delivery_signal.eureka.client.order.infrastructure.client.hub.HubClient;
 import com.delivery_signal.eureka.client.order.infrastructure.client.hub.dto.StockUpdateRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -21,26 +20,20 @@ public class HubCommandAdapter implements HubCommandPort {
     private final HubClient hubClient;
 
     @Override
-    public void deductStocks(UUID hubId, List<OrderProductCommand> products) {
-        List<StockUpdateRequestDto> requests = products.stream()
-                .map(p -> StockUpdateRequestDto.builder()
-                        .productId(p.getProductId())
-                        .quantity(p.getQuantity())
-                        .build())
-                .toList();
+    public void deductStocks(UUID hubId, Map<UUID, Integer> products) {
+        StockUpdateRequestDto request = StockUpdateRequestDto.builder()
+                .products(products)
+                .build();
 
-        hubClient.deductStocks(hubId, requests);
+        hubClient.deductStocks(hubId, request);
     }
 
     @Override
-    public void restoreStocks(UUID hubId, List<OrderProductCommand> products) {
-        List<StockUpdateRequestDto> requests = products.stream()
-                .map(p -> StockUpdateRequestDto.builder()
-                        .productId(p.getProductId())
-                        .quantity(p.getQuantity())
-                        .build())
-                .toList();
+    public void restoreStocks(UUID hubId, Map<UUID, Integer> products) {
+        StockUpdateRequestDto request = StockUpdateRequestDto.builder()
+                .products(products)
+                .build();
 
-        hubClient.restoreStocks(hubId, requests);
+        hubClient.deductStocks(hubId, request);
     }
 }

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/adapter/out/HubCommandAdapter.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/adapter/out/HubCommandAdapter.java
@@ -34,6 +34,6 @@ public class HubCommandAdapter implements HubCommandPort {
                 .products(products)
                 .build();
 
-        hubClient.deductStocks(hubId, request);
+        hubClient.restoreStocks(hubId, request);
     }
 }

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/adapter/out/hubQueryAdapter.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/adapter/out/hubQueryAdapter.java
@@ -2,6 +2,7 @@ package com.delivery_signal.eureka.client.order.infrastructure.adapter.out;
 
 import com.delivery_signal.eureka.client.order.application.port.out.HubQueryPort;
 import com.delivery_signal.eureka.client.order.infrastructure.client.hub.HubClient;
+import com.delivery_signal.eureka.client.order.infrastructure.client.hub.dto.GetStockQuantitiesRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -17,7 +18,13 @@ public class hubQueryAdapter implements HubQueryPort {
 
     @Override
     public Map<UUID, Integer> getStockQuantities(List<UUID> productIds) {
-        return hubClient.getStockQuantities(productIds).getData();
+
+        GetStockQuantitiesRequestDto infraDto =
+                GetStockQuantitiesRequestDto.builder()
+                        .productIds(productIds)
+                        .build();
+
+        return hubClient.getStockQuantities(infraDto).getData();
     }
 
     @Override

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/client/company/CompanyClient.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/client/company/CompanyClient.java
@@ -2,7 +2,6 @@ package com.delivery_signal.eureka.client.order.infrastructure.client.company;
 
 import com.delivery_signal.eureka.client.order.domain.vo.company.CompanyInfo;
 import com.delivery_signal.eureka.client.order.domain.vo.product.ProductInfo;
-import com.delivery_signal.eureka.client.order.infrastructure.client.ApiResponseDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,7 +25,7 @@ public interface CompanyClient {
      * @return CompanyInfo
      */
     @GetMapping("/open-api/v1/companies/{companyId}")
-    ApiResponseDto<CompanyInfo> getCompanyById(@PathVariable("companyId") UUID companyId);
+    CompanyInfo getCompanyById(@PathVariable("companyId") UUID companyId);
 
 
     /**
@@ -42,6 +41,6 @@ public interface CompanyClient {
      * @return 상품리스트
      */
     @GetMapping("/open-api/v1/products")
-    ApiResponseDto<List<ProductInfo>> getProducts(@RequestParam List<UUID> productIds);
+    List<ProductInfo> getProducts(@RequestParam List<UUID> productIds);
 
 }

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/client/hub/HubClient.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/client/hub/HubClient.java
@@ -1,6 +1,7 @@
 package com.delivery_signal.eureka.client.order.infrastructure.client.hub;
 
 import com.delivery_signal.eureka.client.order.infrastructure.client.ApiResponseDto;
+import com.delivery_signal.eureka.client.order.infrastructure.client.hub.dto.GetStockQuantitiesRequestDto;
 import com.delivery_signal.eureka.client.order.infrastructure.client.hub.dto.StockUpdateRequestDto;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,7 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -18,11 +18,11 @@ public interface HubClient {
 
     /**
      * 상품별 재고를 확인하는 API
-     * @param productIds 상품의 id 리스트
+     * @param request 상품의 id 리스트
      * @return 상품 ID별 재고 수량
      */
     @PostMapping("/open-api/v1/stocks")
-    ApiResponseDto<Map<UUID, Integer>> getStockQuantities(@RequestBody List<UUID> productIds);
+    ApiResponseDto<Map<UUID, Integer>> getStockQuantities(@RequestBody GetStockQuantitiesRequestDto request);
 
     /**
      * 허브의 상품 재고를 차감하는 API
@@ -30,7 +30,7 @@ public interface HubClient {
      * @param requests 상품과 수량 리스트
      */
     @PostMapping("/open-api/v1/hubs/{hubId}/stocks/deduct")
-    ApiResponseDto<Void> deductStocks(@PathVariable UUID hubId, @RequestBody List<StockUpdateRequestDto> requests);
+    ApiResponseDto<Void> deductStocks(@PathVariable UUID hubId, @RequestBody StockUpdateRequestDto requests);
 
     /**
      * 허브의 상품 재고를 복원하는 API
@@ -38,7 +38,7 @@ public interface HubClient {
      * @param requests 상품과 수량 리스트
      */
     @PostMapping("/open-api/v1/hubs/{hubId}/stocks/restore")
-    ApiResponseDto<Void> restoreStocks(@PathVariable UUID hubId, @RequestBody List<StockUpdateRequestDto> requests);
+    ApiResponseDto<Void> restoreStocks(@PathVariable UUID hubId, @RequestBody StockUpdateRequestDto requests);
 
     /**
      * 허브의 존재 여부 확인 API

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/client/hub/dto/GetStockQuantitiesRequestDto.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/infrastructure/client/hub/dto/GetStockQuantitiesRequestDto.java
@@ -3,11 +3,11 @@ package com.delivery_signal.eureka.client.order.infrastructure.client.hub.dto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
 @Builder
-public class StockUpdateRequestDto {
-    Map<UUID, Integer> products;
+public class GetStockQuantitiesRequestDto {
+    List<UUID> productIds;
 }

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/presentation/external/dto/response/OrderProductResponseDto.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/presentation/external/dto/response/OrderProductResponseDto.java
@@ -12,8 +12,6 @@ import java.util.UUID;
 @AllArgsConstructor
 public class OrderProductResponseDto {
     private UUID productId;
-    private String productName;
     private Integer quantity;
-    private BigDecimal price;
 }
 

--- a/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/presentation/external/mapper/response/OrderProductResponseMapper.java
+++ b/com.delivery-signal.eureka.client.order/src/main/java/com/delivery_signal/eureka/client/order/presentation/external/mapper/response/OrderProductResponseMapper.java
@@ -8,9 +8,7 @@ public class OrderProductResponseMapper {
     public static OrderProductResponseDto toResponseDto(OrderProductResult result) {
         return OrderProductResponseDto.builder()
                 .productId(result.getProductId())
-                .productName(result.getProductName())
                 .quantity(result.getQuantity())
-                .price(result.getProductPriceAtOrder())
                 .build();
     }
 }

--- a/com.delivery-signal.eureka.client.order/src/main/resources/application.yaml
+++ b/com.delivery-signal.eureka.client.order/src/main/resources/application.yaml
@@ -12,10 +12,11 @@ spring:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
+    properties:
       hibernate:
-        default_schema: order
-      format_sql: true
-      use_sql_comments: true
+        default_schema: p_order
+        format_sql: true
+        use_sql_comments: true
     show-sql: true
 
   data:
@@ -30,8 +31,7 @@ eureka:
     service-url:
       defaultZone: http://localhost:19090/eureka/
   instance:
-    appname: order-service  # 대문자화 방지: 이 이름 그대로 등록됨
-
+    appname: order-service  # 대문자화 방지
 
 server:
   port: 19099

--- a/com.delivery-signal.eureka.client.order/src/test/java/com/delivery_signal/eureka/client/order/application/service/OrderServiceTest.java
+++ b/com.delivery-signal.eureka.client.order/src/test/java/com/delivery_signal/eureka/client/order/application/service/OrderServiceTest.java
@@ -111,8 +111,7 @@ class OrderServiceTest {
                 any(UUID.class),
                 anyString(),
                 anyList(),   // productInfos
-                anyMap(),    // productQuantities
-                any(UUID.class)
+                anyMap()    // productQuantities
         )).thenAnswer(invocation -> {
 
             UUID deliveryId = invocation.getArgument(7);
@@ -186,8 +185,7 @@ class OrderServiceTest {
                 eq(receiverHubId),
                 eq("테스트 주문"),
                 anyList(),
-                anyMap(),
-                any(UUID.class)
+                anyMap()
         );
 
         verify(orderCommandPort).save(any(Order.class));

--- a/com.delivery-signal.eureka.client.order/src/test/java/com/delivery_signal/eureka/client/order/application/service/OrderServiceTest.java
+++ b/com.delivery-signal.eureka.client.order/src/test/java/com/delivery_signal/eureka/client/order/application/service/OrderServiceTest.java
@@ -19,6 +19,7 @@ import org.mockito.*;
 
 import java.math.BigDecimal;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
@@ -213,6 +214,12 @@ class OrderServiceTest {
 
         orderService.createOrderAndSendDelivery(command);
 
-        verify(hubCommandPort).deductStocks(eq(supplierHubId), eq(command.getProducts()));
+        Map<UUID, Integer> expectedMap = command.getProducts().stream()
+                .collect(Collectors.toMap(
+                        OrderProductCommand::getProductId,
+                        OrderProductCommand::getQuantity
+                ));
+
+        verify(hubCommandPort).deductStocks(eq(supplierHubId), eq(expectedMap));
     }
 }


### PR DESCRIPTION
# 🌟 Pull Request

## 🌐 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #120


## 💬 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- 업체, 상품의 내부 api와 주문 FeignClient에 ApiResponse 반환 타입이 제거되었습니다.
- 업체 컨텍스트 내부 상품 컬럼 중 '상품가격'이 그대로 한글로 반영된 컬럼명이 price로 변경되었습니다.
- 주문 생성 시 log가 추가되었습니다.
- 주문 entity에 빌더 패턴이 제거되고 대신 정적 팩토리 메서드를 추가하여 DDD구조에 적합하게 리팩토링했습니다.
- 주문 테스트 코드를 함께 리팩토링했습니다.
- 주문과 허브 통신을 위해 허브 쪽 dto를 주문과 동일하게 변경했습니다. (ERD 기준으로 상품이 product이므로 items를 products로 통일)
- 주문과 허브 통신 중 권한 체크 문제로 인해 재고 차감이 안되는 문제를 발견했습니다. 이 부분은 허브 수정이 필요할 듯 한데 배송 쪽에서 허브를 함께 수정하실 것  같아서 최대한 안 건들이느라고 수정을 못 했습니다. 
- 스키마의 예약어 문제로 인해 .env 파일이 수정되었습니다. 이 부분 수정된 부분은 따로 공유 드리겠습니다! 
- 수정 후 진행상황은 테스트에 로깅으로 첨부합니다. 
- 더미데이터를 활용해서 테스트한 것이라서 더미데이터도 따로 공유 드리겠습니다!

## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->
<img width="1026" height="842" alt="image" src="https://github.com/user-attachments/assets/a7880094-7617-4c93-8e72-e9d51dbca805" />


## 💫 Type
- [ ] 기능
- [ ] 버그
- [x] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [x] 테스트
- [ ] 기타(환경) 
