### PR TITLE
Feat/delivery/#128 주문생성->배송생성 비동기 처리 시 응답 이벤트 발행

### DIFF
--- a/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/application/dto/event/DeliveryCreatedRequestEvent.java
+++ b/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/application/dto/event/DeliveryCreatedRequestEvent.java
@@ -1,0 +1,9 @@
+package com.delivery_signal.eureka.client.delivery.application.dto.event;
+
+import java.util.UUID;
+
+public record DeliveryCreatedRequestEvent(
+    UUID orderId,
+    UUID deliveryId
+) {
+}

--- a/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/application/port/out/OrderMessageResponsePort.java
+++ b/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/application/port/out/OrderMessageResponsePort.java
@@ -1,0 +1,11 @@
+package com.delivery_signal.eureka.client.delivery.application.port.out;
+
+import com.delivery_signal.eureka.client.delivery.application.dto.event.DeliveryCreatedRequestEvent;
+
+/**
+ * [Outbound Port]
+ * 배송 생성 완료 후 Order-Service로 결과를 응답하는 포트 (이벤트 발행)
+ */
+public interface OrderMessageResponsePort {
+    void sendDeliveryCreatedResponse(DeliveryCreatedRequestEvent event);
+}

--- a/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/infrastructure/adapter/rabbitmq/OrderMessageResponseAdapter.java
+++ b/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/infrastructure/adapter/rabbitmq/OrderMessageResponseAdapter.java
@@ -1,0 +1,42 @@
+package com.delivery_signal.eureka.client.delivery.infrastructure.adapter.rabbitmq;
+
+import com.delivery_signal.eureka.client.delivery.application.dto.event.DeliveryCreatedRequestEvent;
+import com.delivery_signal.eureka.client.delivery.application.port.out.OrderMessageResponsePort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * [Outbound Adapter]
+ * OrderMessageResponsePort를 구현하여 RabbitMQ로 배송 생성 완료 응답 메시지를 발행
+ */
+@Slf4j
+@Component
+public class OrderMessageResponseAdapter implements OrderMessageResponsePort {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    @Value("${spring.rabbitmq.exchange.name}")
+    private String exchangeName;
+
+    @Value("${spring.rabbitmq.response.routing.key}")
+    private String responseRoutingKey;
+
+    public OrderMessageResponseAdapter(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    @Override
+    public void sendDeliveryCreatedResponse(DeliveryCreatedRequestEvent event) {
+        log.info(
+            "[DELIVERY -> ORDER] 배송 생성 완료 응답 메시지 발행: Exchange={}, Key={}, deliveryId={}, orderId={}",
+            exchangeName,
+            responseRoutingKey,
+            event.deliveryId(),
+            event.orderId()
+        );
+        // DTO 객체(event)를 RabbitTemplate이 MessageConverter(JSON)를 사용해 변환 후 발행
+        rabbitTemplate.convertAndSend(exchangeName, responseRoutingKey, event);
+    }
+}

--- a/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/infrastructure/config/RabbitConfig.java
+++ b/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/infrastructure/config/RabbitConfig.java
@@ -6,6 +6,8 @@ import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.core.TopicExchange;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -45,6 +47,13 @@ public class RabbitConfig {
 
     @Value("${spring.rabbitmq.delete.routing.key}")
     private String deleteRoutingKey;
+
+    // 응답 큐 (메시지 발행 큐)
+    @Value("${spring.rabbitmq.response.queue.name}")
+    private String responseQueueName;
+
+    @Value("${spring.rabbitmq.response.routing.key}")
+    private String responseRoutingKey;
 
     // DLQ 관련 상수
     public static final String DELIVERY_DLQ_QUEUE = "delivery.dlq.queue";
@@ -128,6 +137,24 @@ public class RabbitConfig {
     }
 
     /**
+     * [RESPONSE] 배송 생성 완료 응답 큐 (Order-Service가 수신하는 큐)
+     */
+    @Bean
+    public Queue deliveryCreatedResponseQueue() {
+        return new Queue(responseQueueName, true);
+    }
+
+    /**
+     * [RESPONSE] Binding: 응답 메시지를 응답 큐로 라우팅
+     */
+    @Bean
+    public Binding bindingResponseQueue(Queue deliveryCreatedResponseQueue, TopicExchange exchange) {
+        return BindingBuilder.bind(deliveryCreatedResponseQueue)
+            .to(exchange)
+            .with(responseRoutingKey);
+    }
+
+    /**
      * JSON 메시지 컨버터
      */
     @Bean
@@ -135,19 +162,11 @@ public class RabbitConfig {
         return new Jackson2JsonMessageConverter();
     }
 
-//    /**
-//     * Listener Container Factory
-//     */
-//    @Bean
-//    public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
-//        ConnectionFactory connectionFactory,
-//        Jackson2JsonMessageConverter messageConverter
-//    ) {
-//        SimpleRabbitListenerContainerFactory factory =
-//            new SimpleRabbitListenerContainerFactory();
-//        factory.setConnectionFactory(connectionFactory);
-//        factory.setMessageConverter(messageConverter);
-//        factory.setDefaultRequeueRejected(false); // DLQ로 전송
-//        return factory;
-//    }
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory,
+        Jackson2JsonMessageConverter messageConverter) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(messageConverter);
+        return rabbitTemplate;
+    }
 }

--- a/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/presentation/adapter/messaging/DeliveryMessageListener.java
+++ b/com.delivery-signal.eureka.client.delivery/src/main/java/com/delivery_signal/eureka/client/delivery/presentation/adapter/messaging/DeliveryMessageListener.java
@@ -2,11 +2,14 @@ package com.delivery_signal.eureka.client.delivery.presentation.adapter.messagin
 
 import com.delivery_signal.eureka.client.delivery.application.command.CreateDeliveryCommand;
 import com.delivery_signal.eureka.client.delivery.application.dto.DeliveryQueryResponse;
+import com.delivery_signal.eureka.client.delivery.application.dto.event.DeliveryCreatedRequestEvent;
 import com.delivery_signal.eureka.client.delivery.application.port.in.DeliveryPort;
+import com.delivery_signal.eureka.client.delivery.application.port.out.OrderMessageResponsePort;
 import com.delivery_signal.eureka.client.delivery.common.exception.PermissionDeniedException;
 import com.delivery_signal.eureka.client.delivery.presentation.dto.request.DeliveryCreateRequest;
 import com.delivery_signal.eureka.client.delivery.presentation.dto.request.DeliveryDeleteRequest;
 import com.delivery_signal.eureka.client.delivery.presentation.mapper.DeliveryPresentationMapper;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -23,10 +26,13 @@ public class DeliveryMessageListener {
 
     private final DeliveryPort deliveryPort;
     private final DeliveryPresentationMapper mapper;
+    private final OrderMessageResponsePort orderMessageResponsePort;
 
-    public DeliveryMessageListener(DeliveryPort deliveryPort, DeliveryPresentationMapper mapper) {
+    public DeliveryMessageListener(DeliveryPort deliveryPort, DeliveryPresentationMapper mapper,
+        OrderMessageResponsePort orderMessageResponsePort) {
         this.deliveryPort = deliveryPort;
         this.mapper = mapper;
+        this.orderMessageResponsePort = orderMessageResponsePort;
     }
 
     @RabbitListener(queues = "${spring.rabbitmq.exchange.queue.name}")
@@ -36,6 +42,14 @@ public class DeliveryMessageListener {
         try {
             CreateDeliveryCommand command = mapper.toCreateDeliveryCommand(request);
             DeliveryQueryResponse response = deliveryPort.createDelivery(command, request.requestUserId());
+
+            UUID orderId = request.orderId();
+            UUID deliveryId = response.deliveryId();
+
+            // 배송 생성 완료 후 Order-Service로 응답 메시지 발행
+            DeliveryCreatedRequestEvent responseEvent = new DeliveryCreatedRequestEvent(orderId,
+                deliveryId);
+            orderMessageResponsePort.sendDeliveryCreatedResponse(responseEvent);
             log.info("[Delivery] 배송 생성 메시지 처리 성공 - 배송 ID: {}", response.deliveryId());
         } catch (IllegalStateException | PermissionDeniedException e) {
             // 비즈니스 검증 실패 -> 재처리 불필요

--- a/com.delivery-signal.eureka.client.delivery/src/main/resources/application.yaml
+++ b/com.delivery-signal.eureka.client.delivery/src/main/resources/application.yaml
@@ -25,6 +25,11 @@ spring:
         name: delivery.create.queue
       routing:
         key: delivery.create.new
+    response:
+      queue:
+        name: delivery.created.response.queue # Order-Service가 응답을 받을 큐 이름
+      routing:
+        key: delivery.created.response
     delete:
       queue:
         name: delivery.delete.queue


### PR DESCRIPTION
# 🌟 Pull Request

## 🌐 Issue Number
<!-- 작업한 이슈 번호를 명시해주세요 -->
closed #128 


## 💬 Description
<!-- 작업 내용에 대한 설명을 적어주세요 -->
- RabbitConfig, application.yml 등 rabbitMQ 설정 수정
- 주문생성->배송생성 메시지 수신 시 응답 이벤트 메시지 발행 (orderId, deliveryId 반환)


## 📒 Test Result
<!-- local에서 postman으로 요청한 결과를 첨부합니다 -->

## 💫 Type
- [x] 기능
- [ ] 버그
- [ ] 리팩토링
- [ ] 파일, 폴더명 수정
- [ ] 파일, 폴더 삭제
- [ ] 문서 수정
- [ ] 테스트
- [ ] 기타(환경) 
